### PR TITLE
Grammar Fixes

### DIFF
--- a/src/installer/alloy.rs
+++ b/src/installer/alloy.rs
@@ -113,15 +113,15 @@ Hunk #1 FAILED at 1.
             println!("stdout: {}", stdout);
             println!("stderr: {}", stderr);
             println!(
-                "Patch failed because of different line endings, even though we've converted them"
+                "Patch failed because of different line endings, even though we've converted them."
             );
-            println!("Please open an issue on github.");
+            println!("Please open an issue on GitHub.");
             exit_or_windows(6);
         } else {
             println!("stdout: {}", stdout);
             println!("stderr: {}", stderr);
             println!("I'm not sure what went wrong");
-            println!("Please open an issue on github.");
+            println!("Please open an issue on GitHub.");
             exit_or_windows(7);
         }
     }
@@ -130,7 +130,7 @@ Hunk #1 FAILED at 1.
         println!("stdout: {}", stdout);
         println!("stderr: {}", stderr);
         println!("Patch command: {}", diff_command.clone());
-        println!("Patch catastrophically failed! Please open an issue on github.");
+        println!("Patch catastrophically failed! Please open an issue on GitHub.");
         exit_or_windows(5);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,6 @@ use std::fs::File;
 use std::io::Cursor;
 use std::path::PathBuf;
 
-//I'm not sure where to add this, but Windows builds don't have a .exe at the end. They run fine if you add it manually, however
-// std::env::consts::EXE_SUFFIX
-//Source: https://stackoverflow.com/questions/40917780/how-to-get-the-executable-extension-across-platforms-in-rust
-
 use crate::installer::inquire::FilePathCompleter;
 use crate::installer::inquire::InquireGamePathValidator;
 use crate::installer::inquire::InquirePathDoesntExistValidator;

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ async fn main() {
 
     println!("");
     println!("One last thing: I need a decompiled daisyMoon folder.");
-    println!("You can either decompile it yourself, or you can download it from the Cobalt Archive");
+    println!("You can either decompile it yourself, or you can download it from the Cobalt Archive:");
     println!("(https://drive.google.com/drive/folders/1jasI5F9X8kWauTzx3fT-qy6_aMJZx_fi)");
     println!("");
     println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,10 @@ use std::fs::File;
 use std::io::Cursor;
 use std::path::PathBuf;
 
+//I'm not sure where to add this, but Windows builds don't have a .exe at the end. They run fine if you add it manually, however
+// std::env::consts::EXE_SUFFIX
+//Source: https://stackoverflow.com/questions/40917780/how-to-get-the-executable-extension-across-platforms-in-rust
+
 use crate::installer::inquire::FilePathCompleter;
 use crate::installer::inquire::InquireGamePathValidator;
 use crate::installer::inquire::InquirePathDoesntExistValidator;
@@ -74,7 +78,7 @@ async fn main() {
     let mut install_dir: Option<PathBuf> = None;
 
     if !create_new_copy {
-        println!("Okay, if you say so..");
+        println!("Okay, if you say so...");
         install_dir = cobalt_dir.clone();
     }
 
@@ -115,7 +119,7 @@ async fn main() {
                 .into();
         }
 
-        let msg = format!("Creating a new copy of Cobalt at {}..", copy_dir.display());
+        let msg = format!("Creating a new copy of Cobalt at {}...", copy_dir.display());
         let mut sp = Spinner::new(Spinners::Dots, msg);
 
         std::fs::create_dir_all(copy_dir.clone()).unwrap();
@@ -268,7 +272,7 @@ async fn main() {
 
     let mut sp = Spinner::new(
         Spinners::Dots,
-        "Syncing line endings with your system..".into(),
+        "Syncing line endings with your system...".into(),
     );
     installer::alloy::fix_line_endings(install_dir.clone().unwrap());
     sp.stop_with_message("Synced line endings!".into());
@@ -277,7 +281,7 @@ async fn main() {
     installer::alloy::patch_daisy_with_alloy(install_dir.clone().unwrap()).await;
     println!("Successfully patched!");
     
-    println!("Writing metadata to make future updating easier..");
+    println!("Writing metadata to make future updating easier...");
     installer::metadata::write_metadata(install_dir.clone().unwrap());
     println!("Done!");
     

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ async fn main() {
     }
 
     if cobalt_dir.is_none() {
-        let prompt = "Please enter your Cobalt game folder path";
+        let prompt = "Please enter your Cobalt game folder path:";
 
         let path = inquire::Text::new(prompt)
             .with_validator(InquireGamePathValidator {})
@@ -51,7 +51,7 @@ async fn main() {
 
     println!("");
     println!(
-        "It is {} recommended to create a new copy of Cobalt for Alloy.",
+        "It is {} recommended you create a new copy of Cobalt for Alloy.",
         "highly".italic()
     );
     println!("Installing to your main copy might break your game");
@@ -129,7 +129,7 @@ async fn main() {
         fs_extra::dir::copy(cobalt_dir.clone().unwrap(), copy_dir.clone(), &options).unwrap();
 
         sp.stop_with_message(format!(
-            "Created new copy of cobalt at {}!",
+            "Created new copy of Cobalt at {}!",
             copy_dir.display()
         ));
 
@@ -137,8 +137,8 @@ async fn main() {
     } 
 
     println!("");
-    println!("One last thing, I need a decompiled daisyMoon folder.");
-    println!("You can either decompile it yourself or you can download it from the Cobalt Archive");
+    println!("One last thing: I need a decompiled daisyMoon folder.");
+    println!("You can either decompile it yourself, or you can download it from the Cobalt Archive");
     println!("(https://drive.google.com/drive/folders/1jasI5F9X8kWauTzx3fT-qy6_aMJZx_fi)");
     println!("");
     println!(
@@ -166,7 +166,7 @@ async fn main() {
                 continue;
             }
 
-            let mut sp = Spinner::new(Spinners::Dots, "Creating daisyMoon folder..".into());
+            let mut sp = Spinner::new(Spinners::Dots, "Creating daisyMoon folder...".into());
 
             let daisy_path = install_dir.clone().unwrap().join("daisyMoon");
 
@@ -186,11 +186,11 @@ async fn main() {
             daisymoon_folder_path = Some(daisy_path);
         } else if let Some(extension) = path.extension() {
             if extension != "zip" {
-                println!("That path is not a folder or zip, please try again.");
+                println!("That path is not a folder or zip; please try again.");
                 continue;
             }
 
-            let mut sp = Spinner::new(Spinners::Dots, "Creating daisyMoon folder..".into());
+            let mut sp = Spinner::new(Spinners::Dots, "Creating daisyMoon folder...".into());
 
             let bytes = std::fs::read(path).unwrap();
 
@@ -227,12 +227,12 @@ async fn main() {
         }
     }
 
-    println!("Installing to {}..", install_dir.clone().unwrap().display());
+    println!("Installing to {}...", install_dir.clone().unwrap().display());
 
     installer::steam::create_app_id_txt(install_dir.clone().unwrap()).await;
     println!("Created appid!");
 
-    let mut sp = Spinner::new(Spinners::Dots, "Downloading Aloy..".into());
+    let mut sp = Spinner::new(Spinners::Dots, "Downloading Alloy...".into());
 
     if let Err(e) = std::fs::create_dir_all(install_dir.clone().unwrap().join(INSTALLER_FOLDER)) {
         println!("Failed to create installer file directory: {}", e);
@@ -251,9 +251,9 @@ async fn main() {
 
     cfg_if! {
         if #[cfg(target_os = "windows")] {
-            println!("Since you're running windows, I'll need to download patch.exe");
+            println!("Since you're running Windows, I'll need to download patch.exe");
 
-            let mut sp = Spinner::new(Spinners::Dots, "Downloading patch..".into());
+            let mut sp = Spinner::new(Spinners::Dots, "Downloading patch...".into());
 
             let patch_dl_result = installer::gnuwin32::get_win32_patch(install_dir.clone().unwrap()).await;
             if let Err(e) = patch_dl_result {


### PR DESCRIPTION
Slight grammar modifications/fixes. As for features, I have used Rust one (1) time before just to try and install a tool I ended up not needing, so I'm sticking to the strings for now.

Application _itself_ runs, had an issue in regards to installing _Alloy_ itself, but I'm assuming that's an issue on my end; the first time, it worked fine.

Also added a comment in main.rs regarding adding the .exe suffix to Windows builds, as the current release doesn't have that (you need to add it manually, to which it works)

Cheers.